### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .DS_Store
 node_modules
 public/build
+
+svelte-app/
+
+# JetBrains
+.idea/


### PR DESCRIPTION
# Desc
- exclude .idea IDE folder from JetBrains
- exclude "svelte-app/" as it seemed generated code

# Review
I'm using WebStorm right now, so I added `.idea` folder. Also Your Readme.md instruction steps created the `svelte-app` folder. It looked this does not need to be checked in as it's generated code.

Let me know if I should change something.